### PR TITLE
Use gosigar library to fetch system wide and per process stats

### DIFF
--- a/config.go
+++ b/config.go
@@ -8,6 +8,7 @@ import (
 
 type TopConfig struct {
 	Period *int64
+	Procs  *[]string
 }
 
 type ConfigSettings struct {

--- a/etc/topbeat.dev.yml
+++ b/etc/topbeat.dev.yml
@@ -1,0 +1,57 @@
+################### Topbeat Configuration Example #########################
+
+############################# Input ############################################
+input:
+ period: 1
+
+############################# Shipper ############################################
+shipper:
+
+ # The name of the shipper that publishes the network data. It can be used to group
+ # all the transactions sent by a single shipper in the web interface.
+ # If this options is not defined, the hostname is used.
+ name:
+
+ # The tags of the shipper are included in their own field with each
+ # transaction published. Tags make it easy to group transactions by different
+ # logical properties.
+ #tags: ["service1"]
+
+############################# Output ############################################
+
+# Configure what outputs to use when sending the data collected by topbeat.
+# You can enable one or multiple outputs by setting enabled option to true.
+output:
+
+  # Elasticsearch as output
+  # Options:
+  # host, port: where Elasticsearch is listening on
+  # save_topology: specify if the topology is saved in Elasticsearch
+  elasticsearch:
+    enabled: false
+    hosts: ["localhost:9200"]
+    save_topology: false
+
+  # Redis as output
+  # Options:
+  # host, port: where Redis is listening on
+  # save_topology: specify if the topology is saved in Redis
+  #redis:
+  #  enabled: true
+  #  host: localhost
+  #  port: 6379
+  #  save_topology: true
+
+  # File as output
+  # Options:
+  # path: where to save the files
+  # filename: name of the files
+  # rotate_every_kb: maximum size of the files in path
+  # number of files: maximum number of files in path
+  file:
+    enabled: true
+    path: "/tmp/topbeat"
+    filename: topbeat
+    rotate_every_kb: 1000
+    number_of_files: 7
+

--- a/etc/topbeat.dev.yml
+++ b/etc/topbeat.dev.yml
@@ -4,6 +4,9 @@
 input:
  period: 1
 
+ procs: [".*"]
+
+
 ############################# Shipper ############################################
 shipper:
 
@@ -28,9 +31,10 @@ output:
   # host, port: where Elasticsearch is listening on
   # save_topology: specify if the topology is saved in Elasticsearch
   elasticsearch:
-    enabled: false
+    enabled: true
     hosts: ["localhost:9200"]
     save_topology: false
+    index: "topbeat"
 
   # Redis as output
   # Options:
@@ -48,10 +52,10 @@ output:
   # filename: name of the files
   # rotate_every_kb: maximum size of the files in path
   # number of files: maximum number of files in path
-  file:
-    enabled: true
-    path: "/tmp/topbeat"
-    filename: topbeat
-    rotate_every_kb: 1000
-    number_of_files: 7
+  #file:
+  #  enabled: true
+  #  path: "/tmp/topbeat"
+  #  filename: topbeat
+  #  rotate_every_kb: 1000
+  #  number_of_files: 7
 

--- a/sigar.go
+++ b/sigar.go
@@ -133,11 +133,11 @@ func GetMemory() (*MemStat, error) {
 		return nil, err
 	}
 	return &MemStat{
-		Total:      mem.Total,
-		Used:       mem.Used,
-		Free:       mem.Free,
-		ActualFree: mem.ActualFree,
-		ActualUsed: mem.ActualUsed,
+		Total:      mem.Total / 1024,
+		Used:       mem.Used / 1024,
+		Free:       mem.Free / 1024,
+		ActualFree: mem.ActualFree / 1024,
+		ActualUsed: mem.ActualUsed / 1024,
 	}, nil
 }
 

--- a/sigar.go
+++ b/sigar.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry/gosigar"
+	"github.com/elastic/libbeat/logp"
+)
+
+type SystemLoad struct {
+	Load1  float64 `json:"load1"`
+	Load5  float64 `json:"load5"`
+	Load15 float64 `json:"load15"`
+}
+
+type CpuTimes struct {
+	User    uint64 `json:"user"`
+	Nice    uint64 `json:"nice"`
+	System  uint64 `json:"system"`
+	Idle    uint64 `json:"idle"`
+	IOWait  uint64 `json:"iowait"`
+	Irq     uint64 `json:"irq"`
+	SoftIrq uint64 `json:"softirq"`
+	Steal   uint64 `json:"steal"`
+}
+
+type MemStat struct {
+	Total      uint64 `json:"total"`
+	Used       uint64 `json:"used"`
+	Free       uint64 `json:"free"`
+	ActualUsed uint64 `json:"actual_used"`
+	ActualFree uint64 `json:"actual_free"`
+}
+
+type ProcMemStat struct {
+	Size     uint64 `json:"size"`
+	Resident uint64 `json:"rss"`
+	Share    uint64 `json:"share"`
+}
+
+type ProcCpuTime struct {
+	User   uint64 `json:"user"`
+	System uint64 `json:"system"`
+	Total  uint64 `json:"total"`
+	Start  string `json:"start_time"`
+}
+
+type Process struct {
+	Pid   int         `json:"pid"`
+	Ppid  int         `json:"ppid"`
+	Name  string      `json:"name"`
+	State string      `json:"state"`
+	Mem   ProcMemStat `json:"mem"`
+	Cpu   ProcCpuTime `json:"cpu"`
+}
+
+func (p *Process) String() string {
+
+	return fmt.Sprintf("pid: %d, ppid: %d, name: %s, state: %s, mem: %s, cpu: %s",
+		p.Pid, p.Ppid, p.Name, p.State, p.Mem.String(), p.Cpu.String())
+}
+
+func (m *ProcMemStat) String() string {
+
+	return fmt.Sprintf("%d size, %d rss, %d share", m.Size, m.Resident, m.Share)
+}
+
+func (t *ProcCpuTime) String() string {
+	return fmt.Sprintf("started at %s, %d total, %d us, %d sys", t.Start, t.Total, t.User, t.System)
+
+}
+
+func (m *MemStat) String() string {
+
+	return fmt.Sprintf("%d total, %d used, %d actual used, %d free, %d actual free", m.Total, m.Used, m.ActualUsed,
+		m.Free, m.ActualFree)
+}
+
+func (t *SystemLoad) String() string {
+
+	return fmt.Sprintf("%.2f %.2f %.2f", t.Load1, t.Load5, t.Load15)
+}
+
+func (t *CpuTimes) String() string {
+
+	return fmt.Sprintf("%d user, %d system, %d nice, %d iddle, %d iowait, %d irq, %d softirq, %d steal",
+		t.User, t.System, t.Nice, t.Idle, t.IOWait, t.Irq, t.SoftIrq, t.Steal)
+}
+
+func GetSystemLoad() (*SystemLoad, error) {
+
+	concreteSigar := sigar.ConcreteSigar{}
+	avg, err := concreteSigar.GetLoadAverage()
+	if err != nil {
+		return nil, err
+	}
+	logp.Debug("topbeat", "load %v\n", avg)
+
+	return &SystemLoad{
+		Load1:  avg.One,
+		Load5:  avg.Five,
+		Load15: avg.Fifteen,
+	}, nil
+}
+
+func GetCpuTimes() (*CpuTimes, error) {
+
+	cpu := sigar.Cpu{}
+	err := cpu.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	logp.Debug("topbeat", "cpu times %v\n", cpu)
+
+	return &CpuTimes{
+		User:    cpu.User,
+		Nice:    cpu.Nice,
+		System:  cpu.Sys,
+		Idle:    cpu.Idle,
+		IOWait:  cpu.Wait,
+		Irq:     cpu.Irq,
+		SoftIrq: cpu.SoftIrq,
+		Steal:   cpu.Stolen,
+	}, nil
+}
+
+func GetMemory() (*MemStat, error) {
+
+	mem := sigar.Mem{}
+	err := mem.Get()
+	if err != nil {
+		return nil, err
+	}
+	return &MemStat{
+		Total:      mem.Total,
+		Used:       mem.Used,
+		Free:       mem.Free,
+		ActualFree: mem.ActualFree,
+		ActualUsed: mem.ActualUsed,
+	}, nil
+}
+
+func GetSwap() (*MemStat, error) {
+
+	swap := sigar.Swap{}
+	err := swap.Get()
+	if err != nil {
+		return nil, err
+	}
+	return &MemStat{
+		Total: swap.Total,
+		Used:  swap.Used,
+		Free:  swap.Free,
+	}, nil
+
+}
+
+func Pids() ([]int, error) {
+
+	pids := sigar.ProcList{}
+	err := pids.Get()
+	if err != nil {
+		return nil, err
+	}
+	return pids.List, nil
+}
+
+func getProcState(b byte) string {
+
+	switch b {
+	case 'S':
+		return "sleeping"
+	case 'R':
+		return "running"
+	case 'D':
+		return "idle"
+	case 'T':
+		return "stopped"
+	case 'Z':
+		return "zombie"
+	}
+	return "<unknown>"
+}
+
+func GetProcess(pid int) (*Process, error) {
+
+	state := sigar.ProcState{}
+	mem := sigar.ProcMem{}
+	time := sigar.ProcTime{}
+
+	err := state.Get(pid)
+	if err != nil {
+		return nil, err
+	}
+
+	err = mem.Get(pid)
+	if err != nil {
+		return nil, err
+	}
+
+	err = time.Get(pid)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Process{
+		Pid:   pid,
+		Ppid:  state.Ppid,
+		Name:  state.Name,
+		State: getProcState(byte(state.State)),
+		Mem: ProcMemStat{
+			Size:     mem.Size / 1024,
+			Resident: mem.Resident / 1024,
+			Share:    mem.Share / 1024,
+		},
+		Cpu: ProcCpuTime{
+			Start:  time.FormatStartTime(),
+			Total:  time.Total,
+			User:   time.User,
+			System: time.Sys,
+		},
+	}, nil
+}


### PR DESCRIPTION
[gosigar](https://github.com/cloudfoundry/gosigar) library implements the libsigar API, but it's a reimplementation of it in Go and cgo. It has good support for Linux and OS X platforms, but very little coverage for Windows, yet. In any case, it's bit ahead of our own [gotop](https://github.com/monicasarbu/gotop) library. So, it makes more sense to contribute to this one. 

It gathers system wide statistics like: system load, memory, swap, cpu usage, list of pids and per process stats like: the process state, name, ppid, pid, virtual and residual memory and cpu times.  

There are two different types of documents that are inserted in Elasticsearch:
1. index=topbeat-*, type=system for system wide stats
2. index=topbeat-*, type=proc for each process stats
This way, it's easier to build statistics for a certain process. 

Configuration:

      input:
       period: 1 //in seconds, specifies how often to dump the stats
       procs: [".*"] // list of regexp, to match the processes for which to export data in ES. By default, all the processes are exported (".*" regexp is used).
