### PR TITLE
Better error handling and moved code in setup

### DIFF
--- a/beat/beat.go
+++ b/beat/beat.go
@@ -3,13 +3,14 @@ package beat
 import (
 	"flag"
 	"fmt"
+	"os"
+	"runtime"
+
 	"github.com/elastic/libbeat/cfgfile"
 	"github.com/elastic/libbeat/logp"
 	"github.com/elastic/libbeat/outputs"
 	"github.com/elastic/libbeat/publisher"
 	"github.com/elastic/libbeat/service"
-	"os"
-	"runtime"
 )
 
 // Beater interface that every beat must use
@@ -63,8 +64,9 @@ func (beat *Beat) CommandLineSetup() {
 	beat.CmdLine.Parse(os.Args[1:])
 
 	if *printVersion {
+		// using Printf because logging not yet initialized
 		fmt.Printf("%s version %s (%s)\n", beat.Name, beat.Version, runtime.GOARCH)
-		return
+		os.Exit(0)
 	}
 }
 
@@ -75,7 +77,9 @@ func (b *Beat) LoadConfig() {
 	err := cfgfile.Read(&b.Config)
 
 	if err != nil {
-		logp.Debug("Log read error", "Error %v\n", err)
+		// using Printf because logging not yet initialized
+		fmt.Printf("Error %v\n", err)
+		os.Exit(1)
 	}
 
 	logp.Init(b.Name, &b.Config.Logging)

--- a/topbeat.go
+++ b/topbeat.go
@@ -27,6 +27,10 @@ type Topbeat struct {
 func (tb *Topbeat) Config(b *beat.Beat) error {
 
 	err := cfgfile.Read(&tb.TbConfig)
+	if err != nil {
+		logp.Err("Error reading configuration file: %v", err)
+		return err
+	}
 
 	if tb.TbConfig.Input.Period != nil {
 		tb.period = time.Duration(*tb.TbConfig.Input.Period) * time.Second
@@ -42,13 +46,13 @@ func (tb *Topbeat) Config(b *beat.Beat) error {
 	logp.Debug("topbeat", "Init toppbeat")
 	logp.Debug("topbeat", "Follow processes %q\n", tb.procs)
 	logp.Debug("topbeat", "Period %v\n", tb.period)
-	tb.events = publisher.Publisher.Queue
 
-	return err
+	return nil
 }
 
 func (tb *Topbeat) Setup(b *beat.Beat) error {
 
+	tb.events = publisher.Publisher.Queue
 	return nil
 }
 


### PR DESCRIPTION
While working on the [dev guide](https://github.com/elastic/libbeat/pull/43) I figured the events channel initializations fits better in the Setup method rather than in Config. Also, there were a few issues with error handling.

@ruflin I made this against topbeat, but the fixes have to end up in libbeat eventually. Let me know if you prefer me to open a PR there.

* Some fixes around the error handling of the configuration file.
* Exit after printing the version.
* Moved the channel initialization in the Setup method, I think it
  makes more sense there.