### PR TITLE
Remove save_topology from the configuration file.

### DIFF
--- a/etc/topbeat.dev.yml
+++ b/etc/topbeat.dev.yml
@@ -29,7 +29,6 @@ output:
   # Elasticsearch as output
   # Options:
   # host, port: where Elasticsearch is listening on
-  # save_topology: specify if the topology is saved in Elasticsearch
   elasticsearch:
     enabled: true
     hosts: ["localhost:9200"]
@@ -38,12 +37,10 @@ output:
   # Redis as output
   # Options:
   # host, port: where Redis is listening on
-  # save_topology: specify if the topology is saved in Redis
   #redis:
   #  enabled: true
   #  host: localhost
   #  port: 6379
-  #  save_topology: true
 
   # File as output
   # Options:

--- a/etc/topbeat.yml
+++ b/etc/topbeat.yml
@@ -31,21 +31,17 @@ output:
   # Elasticsearch as output
   # Options:
   # host, port: where Elasticsearch is listening on
-  # save_topology: specify if the topology is saved in Elasticsearch
   elasticsearch:
     enabled: true
     hosts: ["localhost:9200"]
-    save_topology: false
 
   # Redis as output
   # Options:
   # host, port: where Redis is listening on
-  # save_topology: specify if the topology is saved in Redis
   #redis:
   #  enabled: true
   #  host: localhost
   #  port: 6379
-  #  save_topology: true
 
   # File as output
   # Options:


### PR DESCRIPTION
The save_topology doesn't apply to Topbeat, it's only relevant
for Packetbeat, so having references to it in the default configuration
file is likely to cause confusion.

Therefore, I'd put this in 1.0.0-beta3 and re-test.