### PR TITLE
Add command line options for Topbeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ server monitoring. It is a lightweight agent that installed on your servers,
 reads periodically system wide and per process CPU and memory statistics and indexes them in
 Elasticsearch.
 
-This is quite early stage and not yet released.
-
 ## Exported fields
 
 There are two types of documents exported:

--- a/docs/command-line.asciidoc
+++ b/docs/command-line.asciidoc
@@ -1,0 +1,28 @@
+[[command-line-options]]
+== Command Line Options
+
+[source,shell]
+---------------------------------------------------------
+
+$ ./topbeat -h
+Usage of ./topbeat:
+  -N	Disable actual publishing for testing
+  -c string
+    	Configuration file (default "/etc/topbeat/topbeat.yml")
+  -cpuprofile string
+    	Write cpu profile to file
+  -d string
+    	Enable certain debug selectors
+  -e	Output to stdout and disable syslog/file output
+  -memprofile string
+    	Write memory profile to this file
+  -test
+    	Test configuration and exit.
+  -v	Log at INFO level
+  -version
+    	Print version and exit
+
+---------------------------------------------------------
+
+
+For details about each option, check {libbeat}/command-line-options.html[Beats Command Line Options].

--- a/docs/gettingstarted.asciidoc
+++ b/docs/gettingstarted.asciidoc
@@ -17,7 +17,7 @@ Follow the steps to get started with your own Topbeat setup:
 
 
 [[topbeat-installation]]
-=== Topbeat installation
+=== Installing Topbeat
 
 
 deb:
@@ -77,6 +77,9 @@ input:
   procs: ["^$"]
 -------------------------------------
 
+[[topbeat-template]]
+=== Load index template in Elasticsearch
+
 Before starting topbeat, you need to load the
 http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html[index
 template], which is used to let Elasticsearch know which fields should be analyzed
@@ -94,13 +97,15 @@ curl -XPUT 'http://localhost:9200/_template/topbeat' -d@/etc/topbeat/topbeat.tem
 
 mac:
 
-[source,shell]
+["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 cd topbeat-$PB_VERSION-darwin
 curl -XPUT 'http://localhost:9200/_template/topbeat' -d@topbeat.template.json
 ----------------------------------------------------------------------
 
 where `localhost:9200` is the IP and port where Elasticsearch is listening on.
+
+=== Running Topbeat
 
 You are now ready to start Topbeat:
 

--- a/docs/gettingstarted.asciidoc
+++ b/docs/gettingstarted.asciidoc
@@ -99,7 +99,7 @@ mac:
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
-cd topbeat-$PB_VERSION-darwin
+cd topbeat-{version}-darwin
 curl -XPUT 'http://localhost:9200/_template/topbeat' -d@topbeat.template.json
 ----------------------------------------------------------------------
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -11,6 +11,8 @@ include::./fields.asciidoc[]
 
 // include::./configuration.asciidoc[]
 
+include::./command-line.asciidoc[]
+
 include::./windows.asciidoc[]
 
 include::./dashboards.asciidoc[]


### PR DESCRIPTION
Add details about the command line options for Topbeat and re-organize getting started to have the same sections as other beats.