### PR TITLE
Starting to split the getting started guide into steps

### DIFF
--- a/docs/gettingstarted.asciidoc
+++ b/docs/gettingstarted.asciidoc
@@ -13,6 +13,19 @@ Get started with your own Topbeat setup by:
 After you have Elasticsearch, Kibana and optionally Logstash installed, you can start <<topbeat-installation>>.
 
 
+=== Installing Elasticsearch
+
+https://www.elastic.co/products/elasticsearch[Elasticsearch] is used for storing and indexing 
+the infrastructure metrics collected by Topbeat. {libbeat}/getting-started.html#elasticsearch-installation[Follow the
+Installation Guide]
+
+
+=== Optionally install Logstash
+
+https://www.elastic.co/products/logstash[Logstash] enters the picture by  
+{libbeat}/getting-started.html#logstash-installation[Follow the Installation Guide]
+
+
 [[topbeat-installation]]
 === Installing Topbeat
 


### PR DESCRIPTION
It would be nice to have create a chapter with the link to libbeat for each step in getting started. Right now, we are listing all the steps at the beginning and it might be confusing for the user to know what to do next as he/she has to scroll always up to check the list. 

This is something nice to have, but not mandatory. 

WIP. Please don't merge.