### PR TITLE
Add an explicit "binary" config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,13 @@ test:
 	$(GODEP) go test ./...
 
 
-.PHONY: install_cfg
-install_cfg:
-	cp etc/topbeat.yml $(PREFIX)/topbeat-linux.yml
+.PHONY: install-cfg
+install-cfg:
 	cp etc/topbeat.template.json $(PREFIX)/topbeat.template.json
+	# linux
+	cp etc/topbeat.yml $(PREFIX)/topbeat-linux.yml
+	# binary
+	cp etc/topbeat.yml $(PREFIX)/topbeat-binary.yml
 	# darwin
 	cp etc/topbeat.yml $(PREFIX)/topbeat-darwin.yml
 	# win


### PR DESCRIPTION
Because Filebeat needs a different configuration if it's installed
from packages or from the tar ball, we need the install-cfg target
to install a separate file.

Also take this opportunity to rename install_cfg to install-cfg.