### PR TITLE
Add a field with percentage of actual memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ There are two types of documents exported:
       "free": 5361135616,
       "used_p": 0.69,
       "actual_used": 9940553728,
-      "actual_free": 7239315456
+      "actual_free": 7239315456,
+      "actual_used_p": 0.57
     },
     "shipper": "mar.localdomain",
     "swap": {
@@ -102,7 +103,8 @@ There are two types of documents exported:
       "free": 854327296,
       "used_p": 0.2,
       "actual_used": 0,
-      "actual_free": 0
+      "actual_free": 0,
+      "actual_used_p": 0.0
     },
     "type": "system"
   },

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -212,6 +212,13 @@ type: int
 Actual available memory. Available only on Unix.
 
 
+==== mem.actual_used_p
+
+type: float
+
+Actual used memory, in percentage
+
+
 === swap fields
 
 This group contains statistics related to the swap memory usage on the system.
@@ -257,6 +264,13 @@ Actual used swap memory. Available only on Unix.
 type: int
 
 Actual available swap memory. Available only on Unix.
+
+
+==== swap.actual_used_p
+
+type: float
+
+Actual used swap memory, in percentage
 
 
 [[exported-fields-process]]

--- a/etc/fields.yml
+++ b/etc/fields.yml
@@ -176,6 +176,12 @@ system:
           description: >
             Actual available memory. Available only on Unix.
 
+        - name: actual_used_p
+          path: mem.actual_used_p
+          type: float
+          description: >
+            Actual used memory, in percentage
+
     - name: swap
       type: group
       description: This group contains statistics related to the swap memory usage on the system.
@@ -215,6 +221,12 @@ system:
           type: int
           description: >
             Actual available swap memory. Available only on Unix.
+
+        - name: actual_used_p
+          path: swap.actual_used_p
+          type: float
+          description: >
+            Actual used swap memory, in percentage
 
 process:
   type: group

--- a/etc/topbeat.template.json
+++ b/etc/topbeat.template.json
@@ -62,6 +62,10 @@
         },
         "mem": {
           "properties": {
+            "actual_used_p": {
+              "doc_values": "true",
+              "type": "float"
+            },
             "used_p": {
               "doc_values": "true",
               "type": "float"
@@ -90,6 +94,10 @@
         },
         "swap": {
           "properties": {
+            "actual_used_p": {
+              "doc_values": "true",
+              "type": "float"
+            },
             "used_p": {
               "doc_values": "true",
               "type": "float"

--- a/sigar.go
+++ b/sigar.go
@@ -27,12 +27,13 @@ type CpuTimes struct {
 }
 
 type MemStat struct {
-	Total       uint64  `json:"total"`
-	Used        uint64  `json:"used"`
-	Free        uint64  `json:"free"`
-	UsedPercent float64 `json:"used_p"`
-	ActualUsed  uint64  `json:"actual_used"`
-	ActualFree  uint64  `json:"actual_free"`
+	Total       		uint64  `json:"total"`
+	Used        		uint64  `json:"used"`
+	Free        		uint64  `json:"free"`
+	UsedPercent 		float64 `json:"used_p"`
+	ActualUsed  		uint64  `json:"actual_used"`
+	ActualFree  		uint64  `json:"actual_free"`
+	ActualUsedPercent	float64 `json:"actual_used_p"`
 }
 
 type ProcMemStat struct {

--- a/topbeat.go
+++ b/topbeat.go
@@ -269,6 +269,9 @@ func (t *Topbeat) addMemPercentage(m *MemStat) {
 
 	perc := float64(m.Used) / float64(m.Total)
 	m.UsedPercent = Round(perc, .5, 2)
+
+	actual_perc := float64(m.ActualUsed) / float64(m.Total)
+	m.ActualUsedPercent = Round(actual_perc, .5, 2)
 }
 
 func addFileSystemUsedPercentage(f *FileSystemStat) {

--- a/topbeat_test.go
+++ b/topbeat_test.go
@@ -41,6 +41,25 @@ func TestMemPercentage(t *testing.T) {
 	assert.Equal(t, m.UsedPercent, 0.0)
 }
 
+func TestActualMemPercentage(t *testing.T) {
+
+	beat := Topbeat{}
+
+	m := MemStat{
+		Total: 7,
+		ActualUsed:  5,
+		ActualFree:  2,
+	}
+	beat.addMemPercentage(&m)
+	assert.Equal(t, m.ActualUsedPercent, 0.71)
+
+	m = MemStat{
+		Total: 0,
+	}
+	beat.addMemPercentage(&m)
+	assert.Equal(t, m.ActualUsedPercent, 0.0)
+}
+
 func TestCpuPercentage(t *testing.T) {
 
 	beat := Topbeat{}


### PR DESCRIPTION
Hello !

I recently start using ```topbeat``` at work and wanted to display the percentage of __actual__ memory used by the system.

Haven't found any trace of a discussion about the topic in the forum or in the issues so I'm proposing the following PR.

Hope it makes sense to have such value.

Thanks