### PR TITLE
Set statistics to collect in config file

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,8 +1,13 @@
 package main
 
 type TopConfig struct {
-	Period *int64
-	Procs  *[]string
+	Period     *int64
+	Procs      *[]string
+	Stats struct {
+		System     bool
+		Proc       bool
+		Filesystem bool
+	}
 }
 
 type ConfigSettings struct {

--- a/etc/topbeat.yml
+++ b/etc/topbeat.yml
@@ -2,13 +2,18 @@
 
 ############################# Input ############################################
 input:
- # In seconds, defines how often to read server statistics
- period: 10
+  # In seconds, defines how often to read server statistics
+  period: 10
 
- # Regular expression to match the processes that are monitored
- # By default, all the processes are monitored
- procs: [".*"]
+  # Regular expression to match the processes that are monitored
+  # By default, all the processes are monitored
+  procs: [".*"]
 
+  # Statistics to collect (all enabled by default)
+  stats:
+    system: true
+    proc: true
+    filesystem: true
 
 ############################# Output ##########################################
 


### PR DESCRIPTION
I've extend Topbeat with the possibility of collecting only statistics what the user set in config file.
We use Topbeat in one of our systems but we wouldn't want to store file system information but the current version doesn't allow us to turn off that feature.

Peter