### PR TITLE
Setting coveragemode=atomic because race detector is being used.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ install-cfg:
 cover:
 	# gotestcover is needed to fetch coverage for multiple packages
 	go get github.com/pierrre/gotestcover
-	GOPATH=$(shell $(GODEP) path):$(GOPATH) $(GOPATH)/bin/gotestcover -race -coverprofile=profile.cov -covermode=count github.com/elastic/topbeat/...
+	GOPATH=$(shell $(GODEP) path):$(GOPATH) $(GOPATH)/bin/gotestcover -race -coverprofile=profile.cov -covermode=atomic github.com/elastic/topbeat/...
 	mkdir -p cover
 	$(GODEP) go tool cover -html=profile.cov -o cover/coverage.html
 


### PR DESCRIPTION
When running the race detector and code coverage you must set the `-coveragemode=atomic` or else the race detector finds races with the coverage count instrumentation. This is documented under `go test -help`.

cc: @ruflin (in case you are including `-race` with your libbeat Makefile changes)