### PR TITLE
 	implements remaining technical edits

### DIFF
--- a/docs/command-line.asciidoc
+++ b/docs/command-line.asciidoc
@@ -1,6 +1,8 @@
 [[command-line-options]]
 == Command Line Options
 
+The following command line options are available for Topbeat. For details about each option, see {libbeat}/command-line-options.html[Beats Command Line Options].
+
 [source,shell]
 ---------------------------------------------------------
 
@@ -24,5 +26,3 @@ Usage of ./topbeat:
 
 ---------------------------------------------------------
 
-
-For details about each option, check {libbeat}/command-line-options.html[Beats Command Line Options].

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -32,14 +32,14 @@ format: YYYY-MM-DDTHH:MM:SS.milliZ
 
 required: True
 
-The timestamp when the measurements were taken. The precision is in milliseconds. The timezone is UTC.
+The timestamp of when the measurements were taken. The precision is in milliseconds. The timezone is UTC.
 
 
 ==== type
 
 required: True
 
-Set to "system" to specify that are system wide statistics.
+Set to "system" to indicate that the statistics are system-wide.
 
 
 ==== count
@@ -48,26 +48,26 @@ type: int
 
 required: True
 
-For how many transactions is this event representative. This is generally the inverse of the sampling rate. For example, for a sample rate of 1/10, the count is 10. The count is used by the UIs to return estimated values. Reserved for future usage.
+The number of transactions that this event represents. This is generally the inverse of the sampling rate. For example, for a sample rate of 1/10, the count is 10. The count is used by the UIs to return estimated values. Reserved for future usage.
 
 
 ==== shipper
 
 type: string
 
-Name of the Beat sending the statistics
+The name of the Beat sending the statistics
 
 
 [[exported-fields-system]]
 === System-Wide Statistics Fields
 
-Contains system wide statistics. Details that you can get by running the *top* command on Unix systems.
+Contains system-wide statistics. These statistics are the details that you can get by running the *top* command on Unix systems.
 
 
 
 === load Fields
 
-System load average. The load average is the average number  of jobs in the run queue.
+The system load average. The load average is the average number  of jobs in the run queue.
 
 
 
@@ -75,95 +75,95 @@ System load average. The load average is the average number  of jobs in the run 
 
 type: float
 
-Load average over 1 minute. 
+The load average over 1 minute. 
 
 
 ==== load5
 
 type: float
 
-Load average over 5 minutes.
+The load average over 5 minutes.
 
 
 ==== load15
 
 type: float
 
-Load average over 15 minutes. 
+The load average over 15 minutes. 
 
 
 === cpu Fields
 
-This group contains statistics related to the CPU usage.
+This group contains statistics related to CPU usage.
 
 
 ==== cpu.user
 
 type: int
 
-CPU time spent in user space 
+The amount of CPU time spent in user space.
 
 
 ==== cpu.user_p
 
 type: float
 
-CPU time spent in user space, in percentage. On multi-core systems, you can have percentages that are greater than 100%.  For example, if 3 cores are at 60% use, then the cpu.user_p will be 180%.
+The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%.  For example, if 3 cores are at 60% use, then the +cpu.user_p+ will be 180%.
 
 
 ==== cpu.nice
 
 type: int
 
-CPU time spent on low priority processes
+The amount of CPU time spent on low-priority processes.
 
 
 ==== cpu.system
 
 type: int
 
-CPU time spent in kernel space
+The amount of CPU time spent in kernel space.
 
 
 ==== cpu.system_p
 
 type: float
 
-CPU time spent in kernel space, in percentage.
+The percentage of CPU time spent in kernel space.
 
 
 ==== cpu.idle
 
 type: int
 
-CPU time spent idle
+The amount of CPU time spent idle.
 
 
 ==== cpu.iowait
 
 type: int
 
-CPU time spent in wait (on disk)
+The amount of CPU time spent in wait (on disk).
 
 
 ==== cpu.irq
 
 type: int
 
-CPU time spent servicing/handling hardware interrupts
+The amount of CPU time spent servicing and handling hardware interrupts.
 
 
 ==== cpu.softirq
 
 type: int
 
-CPU time spent servicing/handling software interrupts
+The amount of CPU time spent servicing and handling software interrupts.
 
 ==== cpu.steal
 
 type: int
 
-CPU time in involuntary wait by virtual cpu while hypervisor is servicing another processor CPU time stolen from a virtual machine. Available only on Unix.
+The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor is servicing another processor. Available only on Unix.
 
 === mem Fields
 
@@ -174,28 +174,28 @@ This group contains statistics related to the memory usage on the system.
 
 type: int
 
-Total memory
+Total memory.
 
 
 ==== mem.used
 
 type: int
 
-Used memory
+Used memory.
 
 
 ==== mem.free
 
 type: int
 
-Available memory
+Available memory.
 
 
 ==== mem.used_p
 
 type: float
 
-Used memory, in percentage
+The percentage of used memory.
 
 
 ==== mem.actual_used
@@ -216,7 +216,7 @@ Actual available memory. Available only on Unix.
 
 type: float
 
-Actual used memory, in percentage
+The percentage of actual used memory.
 
 
 === swap Fields
@@ -228,28 +228,28 @@ This group contains statistics related to the swap memory usage on the system.
 
 type: int
 
-Total swap memory
+Total swap memory.
 
 
 ==== swap.used
 
 type: int
 
-Used swap memory
+Used swap memory.
 
 
 ==== swap.free
 
 type: int
 
-Available swap memory
+Available swap memory.
 
 
 ==== swap.used_p
 
 type: float
 
-Used swap memory, in percentage
+The percentage of used swap memory.
 
 
 ==== swap.actual_used
@@ -270,7 +270,7 @@ Actual available swap memory. Available only on Unix.
 
 type: float
 
-Actual used swap memory, in percentage
+The percentage of actual used swap memory.
 
 
 [[exported-fields-process]]
@@ -282,7 +282,7 @@ Per-process statistics that you can get by running the *top* or *ps* command on 
 
 === proc Fields
 
-Contains per-process statistics like memory usage, CPU usage and details about each process like state, name, pid, ppid.
+Contains per-process statistics like memory usage, CPU usage, and details about each process, such as state, name, pid, and ppid.
 
 
 
@@ -290,113 +290,113 @@ Contains per-process statistics like memory usage, CPU usage and details about e
 
 type: string
 
-Process name.
+The process name.
 
 
 ==== proc.state
 
 type: string
 
-Process state. Example: "running"
+The process state. For example: "running"
 
 
 ==== proc.pid
 
 type: int
 
-Process pid.
+The process pid.
 
 
 ==== proc.ppid
 
 type: int
 
-Process parent pid.
+The process parent pid.
 
 
 === cpu Fields
 
-CPU specific statistics per process.
+CPU-specific statistics per process.
 
 
 ==== proc.cpu.user
 
 type: int
 
-CPU time spent in user space by the process.
+The amount of CPU time the process spent in user space.
 
 
 ==== proc.cpu.user_p
 
 type: float
 
-CPU time spent in user space by the process, in percentage.
+The percentage of CPU time the process spent in user space.
 
 
 ==== proc.cpu.system
 
 type: int
 
-CPU time spent in kernel space by the process.
+The amount of CPU time the process spent in kernel space.
 
 
 ==== proc.cpu.total
 
 type: int
 
-Total CPU time spent by the process.
+The total CPU time spent by the process.
 
 
 ==== proc.cpu.start_time
 
 type: string
 
-Time when the process was started. Example: "17:45".
+The time when the process was started. Example: "17:45".
 
 
 === mem Fields
 
-Memory specific statistics per process.
+Memory-specific statistics per process.
 
 
 ==== proc.mem.size
 
 type: int
 
-Virtual memory the process has in total.
+The total virtual memory the process has.
 
 
 ==== proc.mem.rss
 
 type: int
 
-Resident Set Size. Memory occupied by the process in main memory (RAM).
+The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
 
 
 ==== proc.mem.rss_p
 
 type: float
 
-Memory occupied by the process in main memory (RAM), in percentage.
+The percentage of memory the process occupied in main memory (RAM).
 
 
 ==== proc.mem.share
 
 type: int
 
-Shared memory the process uses.
+The shared memory the process uses.
 
 
 [[exported-fields-filesystem]]
 === File System Statistics Fields
 
-File system related statistics that you can get by using the *df* command on Unix systems.
+File system-related statistics that you can get by using the *df* command on Unix systems.
 
 
 
 === fs Fields
 
-Contains details about the mounted disks like the total or used disk space and details about each disk like device name and the mounting place.
+Contains details about the mounted disks, such as the total or used disk space, and details about each disk, such as  the device name and the mounting place.
 
 
 
@@ -404,55 +404,55 @@ Contains details about the mounted disks like the total or used disk space and d
 
 type: int
 
-Available disk space in bytes.
+The available disk space in bytes.
 
 
 ==== fs.device_name
 
 type: string
 
-Disk name. Example: /dev/disk1
+The disk name. For example: +/dev/disk1+
 
 
 ==== fs.mount_point
 
 type: string
 
-Mounting point. Example: /
+The mounting point. For example: +/+
 
 
 ==== fs.files
 
 type: int
 
-Total file nodes in the file system. 
+The total number of file nodes in the file system. 
 
 
 ==== fs.free_files
 
 type: int
 
-Free file nodes in the file system.
+The number of free file nodes in the file system.
 
 
 ==== fs.total
 
 type: int
 
-Total disk space in bytes.
+The total disk space in bytes.
 
 
 ==== fs.used
 
 type: int
 
-Used disk space in bytes.
+The used disk space in bytes.
 
 
 ==== fs.used_p
 
 type: float
 
-Used disk space in percentage
+The percentage of used disk space.
 
 

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -163,7 +163,7 @@ The amount of CPU time spent servicing and handling software interrupts.
 
 type: int
 
-The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor is servicing another processor. Available only on Unix.
+The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix.
 
 === mem Fields
 

--- a/docs/windows.asciidoc
+++ b/docs/windows.asciidoc
@@ -1,42 +1,44 @@
 
-== Windows Support
+== Installing Topbeat on Windows
 
 This page walks you through the steps required for running Topbeat on
 Windows. It assumes your Windows system has Powershell installed.
 
-Start by downloading the Topbeat Windows zip file from the
+To install and run Topbeat:
+
+. Download the Topbeat Windows zip file from the
 https://www.elastic.co/downloads/beats/topbeat[downloads page] and unzip
-it on your computer. The location where it is extracted is not important, but
+it on your computer. The location where you extract the file is not important, but
 remember that you shouldn't delete this repository after the installation is
 finished. The exe file and the configuration file will continue to live there.
 
-You might want to change some settings in the `topbeat.yml` file. See the
+. If necessary, edit settings in the `topbeat.yml` file. See the
  <<topbeat-configuration>> section.
 
-Then start an Administrator Powershell session (right click the Powershell icon
-and select *Run as Administrator*), and navigate to where you uncompressed the
+. Start an Administrator Powershell session (right click the Powershell icon
+and select *Run as Administrator*), and navigate to where you extracted the
 zip file.
 
-Then you can install Topbeat as a Windows service by using the following
+. Install Topbeat as a Windows service by using the following
 Powershell script:
-
++
 [source,shell]
 ----------------------------------------------------------------------
 PS > .\install-service-topbeat.ps1
 ----------------------------------------------------------------------
 
-And then start it with:
-
+. To start the Topbeat service, issue this command:
++
 [source,shell]
 ----------------------------------------------------------------------
 PS > Start-Service topbeat
 ----------------------------------------------------------------------
-
-By default the log files can be found under `C:\ProgramData\topbeat\Logs`.
++
+By default the log files are stored in `C:\ProgramData\topbeat\Logs`.
 
 === Known Limitations
 
-On Windows, some statistics are not captured:
+On Windows, the following statistics are not captured:
 
 * System load
 * Swap usage statistics

--- a/etc/fields.yml
+++ b/etc/fields.yml
@@ -132,7 +132,7 @@ system:
           type: int
           description:
             The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
-            is servicing another processor.
+            was servicing another processor.
             Available only on Unix.
 
 

--- a/etc/fields.yml
+++ b/etc/fields.yml
@@ -18,18 +18,18 @@ env:
       format: YYYY-MM-DDTHH:MM:SS.milliZ
       example: 2015-01-24T14:06:05.071Z
       description: >
-        The timestamp when the measurements were taken. The precision is in milliseconds.
+        The timestamp of when the measurements were taken. The precision is in milliseconds.
         The timezone is UTC.
 
     - name: type
       description: >
-        Set to "system" to specify that are system wide statistics.
+        Set to "system" to indicate that the statistics are system-wide.
       required: true
 
     - name: count
       type: int
       description: >
-        For how many transactions is this event representative. This
+        The number of transactions that this event represents. This
         is generally the inverse of the sampling rate. For example, for
         a sample rate of 1/10, the count is 10. The count is used by the
         UIs to return estimated values. Reserved for future usage.
@@ -38,101 +38,101 @@ env:
     - name: shipper
       type: string
       description: >
-        Name of the Beat sending the statistics
+        The name of the Beat sending the statistics
 
 
 system:
   type: group
   description: >
-    Contains system wide statistics. Details that you can get by running the *top* command on Unix systems.
+    Contains system-wide statistics. These statistics are the details that you can get by running the *top* command on Unix systems.
   fields:
     - name: load
       type: group
       description: > 
-        System load average. The load average is the average number 
+        The system load average. The load average is the average number 
         of jobs in the run queue.
       fields:
         - name: load1
           type: float
           description: >
-            Load average over 1 minute. 
+            The load average over 1 minute. 
 
         - name: load5
           type: float
           description: >
-            Load average over 5 minutes.
+            The load average over 5 minutes.
 
         - name: load15
           type: float
           description: >
-            Load average over 15 minutes. 
+            The load average over 15 minutes. 
 
     - name: cpu
       type: group
-      description: This group contains statistics related to the CPU usage. 
+      description: This group contains statistics related to CPU usage. 
       fields:
         - name: user
           path: cpu.user
           type: int
           description: >
-            CPU time spent in user space 
+           The amount of CPU time spent in user space.
 
         - name: user_p
           path: cpu.user_p
           type: float
           description: >
-            CPU time spent in user space, in percentage. On multi-core systems, you can have percentages that are greater than 100%. 
-            For example, if 3 cores are at 60% use, then the cpu.user_p will be 180%.
+            The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%. 
+            For example, if 3 cores are at 60% use, then the +cpu.user_p+ will be 180%.
 
         - name: nice
           path: cpu.nice
           type: int
           description: >
-            CPU time spent on low priority processes
+            The amount of CPU time spent on low-priority processes.
 
 
         - name: system
           path: cpu.system
           type: int
           description: >
-            CPU time spent in kernel space
+            The amount of CPU time spent in kernel space.
 
         - name: system_p
           path: cpu.system_p
           type: float
           description: >
-            CPU time spent in kernel space, in percentage.
+            The percentage of CPU time spent in kernel space.
 
         - name: idle
           path: cpu.idle
           type: int
           description: >
-            CPU time spent idle
+            The amount of CPU time spent idle.
 
         - name: iowait
           path: cpu.iowait
           type: int
           description: >
-            CPU time spent in wait (on disk)
+            The amount of CPU time spent in wait (on disk).
 
         - name: irq
           path: cpu.irq
           type: int
           description: >
-            CPU time spent servicing/handling hardware interrupts
+            The amount of CPU time spent servicing and handling hardware interrupts.
 
         - name: softirq
           path: cpu.softirq
           type: int
           description:
-            CPU time spent servicing/handling software interrupts
+            The amount of CPU time spent servicing and handling software interrupts.
 
         - name: steal
           path: cpu.steal
           type: int
           description:
-            CPU time in involuntary wait by virtual cpu while hypervisor 
-            is servicing another processor CPU time stolen from a virtual machine.
+            The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
+            is servicing another processor.
             Available only on Unix.
 
 
@@ -144,25 +144,25 @@ system:
           path: mem.total
           type: int
           description: >
-            Total memory
+            Total memory.
 
         - name: used
           path: mem.used
           type: int
           description: >
-            Used memory
+            Used memory.
 
         - name: free
           path: mem.free
           type: int
           description: >
-            Available memory
+            Available memory.
 
         - name: used_p
           path: mem.used_p
           type: float
           description: >
-            Used memory, in percentage
+            The percentage of used memory.
 
         - name: actual_used
           path: mem.actual_used
@@ -180,7 +180,7 @@ system:
           path: mem.actual_used_p
           type: float
           description: >
-            Actual used memory, in percentage
+            The percentage of actual used memory.
 
     - name: swap
       type: group
@@ -190,25 +190,25 @@ system:
           path: swap.total
           type: int
           description: >
-            Total swap memory
+            Total swap memory.
 
         - name: used
           path: swap.used
           type: int
           description: >
-            Used swap memory
+            Used swap memory.
 
         - name: free
           path: swap.free
           type: int
           description: >
-            Available swap memory
+            Available swap memory.
 
         - name: used_p
           path: swap.used_p
           type: float
           description: >
-            Used swap memory, in percentage
+            The percentage of used swap memory.
 
         - name: actual_used
           path: swap.actual_used
@@ -226,7 +226,7 @@ system:
           path: swap.actual_used_p
           type: float
           description: >
-            Actual used swap memory, in percentage
+            The percentage of actual used swap memory.
 
 process:
   type: group
@@ -236,150 +236,150 @@ process:
     - name: proc
       type: group
       description: >
-        Contains per-process statistics like memory usage, CPU usage and details about each process like state, name,
-        pid, ppid.
+        Contains per-process statistics like memory usage, CPU usage, and details about each process, such as state, name,
+        pid, and ppid.
       fields:
         - name: name
           path: proc.name
           type: string
           description: >
-            Process name.
+            The process name.
 
         - name: state
           path: proc.state
           type: string
           description: >
-            Process state. Example: "running"
+            The process state. For example: "running"
 
         - name: pid
           path: proc.pid
           type: int
           description: >
-            Process pid.
+            The process pid.
 
         - name: ppid
           path: proc.ppid
           type: int
           description: >
-            Process parent pid.
+            The process parent pid.
 
         - name: cpu
           type: group
-          description: CPU specific statistics per process.
+          description: CPU-specific statistics per process.
           fields:
             - name: user
               path: proc.cpu.user
               type: int
               description: >
-                CPU time spent in user space by the process.
+                The amount of CPU time the process spent in user space.
 
             - name: user_p
               path: proc.cpu.user_p
               type: float
               description: >
-                CPU time spent in user space by the process, in percentage.
+                The percentage of CPU time the process spent in user space.
 
             - name: system
               path: proc.cpu.system
               type: int
               description: >
-                CPU time spent in kernel space by the process.
+                The amount of CPU time the process spent in kernel space.
 
             - name: total
               path: proc.cpu.total
               type: int
               description: >
-                Total CPU time spent by the process.
+                The total CPU time spent by the process.
 
             - name: start_time
               path: proc.cpu.start_time
               type: string
               description: >
-                Time when the process was started. Example: "17:45".
+                The time when the process was started. Example: "17:45".
 
         - name: mem
           type: group
-          description: Memory specific statistics per process.
+          description: Memory-specific statistics per process.
           fields:
             - name: size
               path: proc.mem.size
               type: int
               description: >
-                Virtual memory the process has in total.
+                The total virtual memory the process has.
 
             - name: rss
               path: proc.mem.rss
               type: int
               description: >
-                Resident Set Size. Memory occupied by the process in main memory (RAM).
+                The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
 
             - name: rss_p
               path: proc.mem.rss_p
               type: float
               description: >
-                Memory occupied by the process in main memory (RAM), in percentage.
+                The percentage of memory the process occupied in main memory (RAM).
 
             - name: share
               path: proc.mem.share
               type: int
               description: >
-                Shared memory the process uses.
+                The shared memory the process uses.
 
 filesystem:
   type: group
   description: >
-    File system related statistics that you can get by using the *df* command on Unix systems.
+    File system-related statistics that you can get by using the *df* command on Unix systems.
   fields:
     - name: fs
       type: group
       description: >
-        Contains details about the mounted disks like the total or used disk space and details about each disk like
-        device name and the mounting place.
+        Contains details about the mounted disks, such as the total or used disk space, and details about each disk, such as 
+        the device name and the mounting place.
       fields:
         - name: avail
           path: fs.avail
           type: int
           description: >
-            Available disk space in bytes.
+            The available disk space in bytes.
   
         - name: device_name
           path: fs.device_name
           type: string
           description: >
-            Disk name. Example: /dev/disk1
+            The disk name. For example: +/dev/disk1+
 
         - name: mount_point
           path: fs.mount_point
           type: string
           description: >
-            Mounting point. Example: /
+            The mounting point. For example: +/+
 
         - name: files
           path: fs.files
           type: int
           description: >
-            Total file nodes in the file system. 
+            The total number of file nodes in the file system. 
 
         - name: free_files
           path: fs.free_files
           type: int
           description: >
-            Free file nodes in the file system.
+            The number of free file nodes in the file system.
 
         - name: total
           path: fs.total
           type: int
           description: >
-            Total disk space in bytes.
+            The total disk space in bytes.
 
         - name: used
           path: fs.used
           type: int
           description: >
-            Used disk space in bytes.
+            The used disk space in bytes.
 
         - name: used_p
           path: fs.used_p
           type: float
           description: >
-            Used disk space in percentage
+            The percentage of used disk space.


### PR DESCRIPTION
Technical edits to improve clarity and consistency. Note that in the Exported Fields topic I changed the structure of entries like the following one because the sentences were grammatically ambiguous:

"Memory occupied by the process in main memory (RAM)."

As it's written, this sentence is basically saying that there is a process in main memory and here is the amount of memory that is occupied by that process. But because of how the sentence is structured, the memory wouldn't have to be in main memory. 

What I think you meant was: "The amount of memory that the process occupied in main memory."

Note that adding "amount of" makes it clear that you aren't talking about a memory address or something else (which is obvious if you look at the type, but it's better to just state it directly). 
