### PR TITLE
minor fix to formatting character used in fields.yml

### DIFF
--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -108,7 +108,7 @@ The amount of CPU time spent in user space.
 
 type: float
 
-The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%.  For example, if 3 cores are at 60% use, then the +cpu.user_p+ will be 180%.
+The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%.  For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
 
 
 ==== cpu.nice
@@ -411,14 +411,14 @@ The available disk space in bytes.
 
 type: string
 
-The disk name. For example: +/dev/disk1+
+The disk name. For example: `/dev/disk1`
 
 
 ==== fs.mount_point
 
 type: string
 
-The mounting point. For example: +/+
+The mounting point. For example: `/`
 
 
 ==== fs.files

--- a/etc/fields.yml
+++ b/etc/fields.yml
@@ -82,7 +82,7 @@ system:
           type: float
           description: >
             The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%. 
-            For example, if 3 cores are at 60% use, then the +cpu.user_p+ will be 180%.
+            For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
 
         - name: nice
           path: cpu.nice
@@ -346,13 +346,13 @@ filesystem:
           path: fs.device_name
           type: string
           description: >
-            The disk name. For example: +/dev/disk1+
+            The disk name. For example: `/dev/disk1`
 
         - name: mount_point
           path: fs.mount_point
           type: string
           description: >
-            The mounting point. For example: +/+
+            The mounting point. For example: `/`
 
         - name: files
           path: fs.files


### PR DESCRIPTION
I'm not sure if this fix is necessary, but I used the + formatting character and then realized that the fields.yml might be used for something other than generating the doc, so I changed it to the ` character. If the ` character is not allowed for formatting, let me know, and I can remove it completely.