### PR TITLE
Set supported cross-compile OS/arches

### DIFF
--- a/scripts/crosscompile.bash
+++ b/scripts/crosscompile.bash
@@ -25,6 +25,9 @@
 # nacl and plan9 are currently not compatible
 # If you want to build only a specific platform, set the PLATFORMS variable
 # go-build-all to ignore.
+
+# Linux is the only platform that is supported by gosigar without using cgo therefore
+# it is the only platform that can be cross-compiled without a gcc cross-compiler.
 : ${PLATFORMS:="
 linux-386
 linux-386-387
@@ -37,23 +40,23 @@ linux-ppc64le
 #nacl-386
 #nacl-amd64p32
 #nacl-arm
-darwin-386
-darwin-amd64
-dragonfly-amd64
-freebsd-386
-freebsd-amd64
-freebsd-arm
-netbsd-386
-netbsd-amd64
-netbsd-arm
-openbsd-386
-openbsd-amd64
-openbsd-arm
+#darwin-386
+#darwin-amd64
+#dragonfly-amd64
+#freebsd-386
+#freebsd-amd64
+#freebsd-arm
+#netbsd-386
+#netbsd-amd64
+#netbsd-arm
+#openbsd-386
+#openbsd-amd64
+#openbsd-arm
 #plan9-386
 #plan9-amd64
-solaris-amd64
-windows-386
-windows-amd64
+#solaris-amd64
+#windows-386
+#windows-amd64
 "}
 
 # Build for all platforms. Any failures will be reported at the end.


### PR DESCRIPTION
Disabling OS and arches that cannot be cross-compiled without a gcc cross-compiler.

- BSD is not supported by gosigar.
- Solaris is not supported by gosigar.
- Windows uses cgo.
- Darwin uses cgo.