### PR TITLE
Fixes capitalization in guide title

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,4 @@
-= Topbeat reference
+= Topbeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.0.0
 :version: 1.0.0
 


### PR DESCRIPTION
Not sure how these titles got regressed, but title case is what we want here.