### PR TITLE
Change proc type to process type to make it work with ES 1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file based on the
 ## [1.0.0](https://github.com/elastic/topbeat/compare/1.0.0-rc2...1.0.0) - 2015-11-24
 
 ### Backward Compatibility Breaks
+- Change proc type to process #138
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can find the documentation on the [elastic.co](https://www.elastic.co/guide/
 
 There are three types of documents exported:
 - `type: system` for system wide statistics
-- `type: proc` for per process statistics. One per process.
+- `type: process` for per process statistics. One per process.
 - `type: filesystem` for disk usage statistics. One per mount point.
 
 System statistics:

--- a/topbeat.go
+++ b/topbeat.go
@@ -196,7 +196,7 @@ func (t *Topbeat) exportProcStats() error {
 
 			event := common.MapStr{
 				"@timestamp": common.Time(time.Now()),
-				"type":       "proc",
+				"type":       "process",
 				"proc": common.MapStr{
 					"pid":   process.Pid,
 					"ppid":  process.Ppid,


### PR DESCRIPTION
This is needed for Elasticsearch 1.7.x to pick the right key for proc.name. Otherwise there was a confusion with the proc type.